### PR TITLE
feat: Add flexible safe withdrawal rate support

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -36,11 +36,18 @@ export {
   clearCustomAllocationTool,
 } from "./assetAllocationTools.js";
 
+// Withdrawal rate tools
+export {
+  suggestWithdrawalRateTool,
+  calculateTargetWithSWRTool,
+} from "./withdrawalRateTools.js";
+
 // Combined tool list for session creation
 import { compoundGrowthTool, inflationTool, retirementTargetTool, retirementAgeTool } from "./calculationTools.js";
 import { loadProfileTool, saveProfileTool, checkProfileTool, deleteProfileTool } from "./profileTools.js";
 import { addIncomeFlowTool, listIncomeFlowsTool, removeIncomeFlowTool, calculateIncomeFlowImpactTool } from "./incomeFlowTools.js";
 import { setAssetAllocationTool, calculateAllocationReturnTool, suggestAllocationTool, showPresetAllocationsTool, getCurrentAllocationTool, clearCustomAllocationTool } from "./assetAllocationTools.js";
+import { suggestWithdrawalRateTool, calculateTargetWithSWRTool } from "./withdrawalRateTools.js";
 
 /**
  * All tools available to the retirement planning advisor.
@@ -68,4 +75,7 @@ export const retirementTools = [
   showPresetAllocationsTool,
   getCurrentAllocationTool,
   clearCustomAllocationTool,
+  // Withdrawal rate tools
+  suggestWithdrawalRateTool,
+  calculateTargetWithSWRTool,
 ];

--- a/src/tools/withdrawalRateTools.ts
+++ b/src/tools/withdrawalRateTools.ts
@@ -1,0 +1,112 @@
+import { defineTool } from "@github/copilot-sdk";
+import {
+  suggestWithdrawalRate,
+  calculateRetirementTargetWithSWR,
+} from "../lib/calculations.js";
+
+/**
+ * Parameters for suggesting a withdrawal rate.
+ */
+export interface SuggestWithdrawalRateParams {
+  retirementYears: number;
+}
+
+/**
+ * Parameters for calculating retirement target with custom SWR.
+ */
+export interface CalculateTargetWithSWRParams {
+  monthlyExpenses: number;
+  withdrawalRate: number;
+}
+
+/**
+ * Tool for suggesting a safe withdrawal rate based on retirement length.
+ */
+export const suggestWithdrawalRateTool = defineTool<SuggestWithdrawalRateParams>(
+  "suggestWithdrawalRate",
+  {
+    description:
+      "Suggest an appropriate safe withdrawal rate (SWR) based on expected retirement length. " +
+      "The traditional 4% rule assumes a 30-year retirement. Longer retirements need lower rates " +
+      "to reduce the risk of running out of money, while shorter retirements can use higher rates. " +
+      "Use this when the user's retirement length differs significantly from 30 years.",
+    parameters: {
+      type: "object",
+      properties: {
+        retirementYears: {
+          type: "number",
+          description:
+            "Expected number of years in retirement (e.g., age 95 minus retirement age)",
+        },
+      },
+      required: ["retirementYears"],
+    },
+    handler: async (args) => {
+      const guidance = suggestWithdrawalRate(args.retirementYears);
+      return {
+        retirementYears: args.retirementYears,
+        standardRate: guidance.standardRate,
+        conservativeRate: guidance.conservativeRate,
+        standardRatePercent: `${(guidance.standardRate * 100).toFixed(2)}%`,
+        conservativeRatePercent: `${(guidance.conservativeRate * 100).toFixed(2)}%`,
+        description: guidance.description,
+        summary:
+          `For a ${args.retirementYears}-year retirement: ` +
+          `standard rate is ${(guidance.standardRate * 100).toFixed(1)}%, ` +
+          `conservative rate is ${(guidance.conservativeRate * 100).toFixed(2)}%. ` +
+          guidance.description,
+      };
+    },
+  }
+);
+
+/**
+ * Tool for calculating retirement target with a specific withdrawal rate.
+ */
+export const calculateTargetWithSWRTool = defineTool<CalculateTargetWithSWRParams>(
+  "calculateRetirementTargetWithSWR",
+  {
+    description:
+      "Calculate how much total savings is needed for retirement based on expected monthly expenses " +
+      "and a specific safe withdrawal rate. Use this when the user wants a different rate than the " +
+      "default 4% rule (e.g., for longer or shorter retirements).",
+    parameters: {
+      type: "object",
+      properties: {
+        monthlyExpenses: {
+          type: "number",
+          description: "Expected monthly expenses in retirement in dollars",
+        },
+        withdrawalRate: {
+          type: "number",
+          description:
+            "Safe withdrawal rate as a decimal (e.g., 0.035 for 3.5%)",
+        },
+      },
+      required: ["monthlyExpenses", "withdrawalRate"],
+    },
+    handler: async (args) => {
+      const target = calculateRetirementTargetWithSWR(
+        args.monthlyExpenses,
+        args.withdrawalRate
+      );
+      const annualExpenses = args.monthlyExpenses * 12;
+      const multiplier = Math.round(1 / args.withdrawalRate);
+      
+      return {
+        monthlyExpenses: args.monthlyExpenses,
+        annualExpenses,
+        withdrawalRate: args.withdrawalRate,
+        withdrawalRatePercent: `${(args.withdrawalRate * 100).toFixed(2)}%`,
+        targetSavings: target,
+        multiplier,
+        summary:
+          `To support $${args.monthlyExpenses.toLocaleString()}/month ` +
+          `($${annualExpenses.toLocaleString()}/year) in retirement with a ` +
+          `${(args.withdrawalRate * 100).toFixed(1)}% withdrawal rate, ` +
+          `you need approximately $${target.toLocaleString()} saved ` +
+          `(${multiplier}x annual expenses)`,
+      };
+    },
+  }
+);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -106,6 +106,32 @@ export const RISK_TOLERANCE_RATES: Record<
 export const DEFAULT_INFLATION_RATE = 0.03;
 
 /**
+ * Safe withdrawal rate guidance based on retirement length.
+ */
+export interface SWRGuidance {
+  /** Number of years in retirement */
+  retirementYears: number;
+  /** Standard withdrawal rate (decimal, e.g., 0.04 for 4%) */
+  standardRate: number;
+  /** More conservative withdrawal rate for added safety */
+  conservativeRate: number;
+  /** Description of when this guidance applies */
+  description: string;
+}
+
+/**
+ * SWR guidance table based on retirement length.
+ * Longer retirements need lower withdrawal rates to reduce failure risk.
+ */
+export const SWR_GUIDANCE_TABLE: SWRGuidance[] = [
+  { retirementYears: 20, standardRate: 0.050, conservativeRate: 0.045, description: "Short retirement (~20 years)" },
+  { retirementYears: 25, standardRate: 0.045, conservativeRate: 0.040, description: "Moderate retirement (~25 years)" },
+  { retirementYears: 30, standardRate: 0.040, conservativeRate: 0.035, description: "Standard retirement (~30 years)" },
+  { retirementYears: 35, standardRate: 0.035, conservativeRate: 0.0325, description: "Long retirement (~35 years)" },
+  { retirementYears: 40, standardRate: 0.0325, conservativeRate: 0.030, description: "Very long retirement (40+ years)" },
+];
+
+/**
  * Historical average annual returns by asset class.
  * These are nominal returns before inflation adjustment.
  */


### PR DESCRIPTION
## Summary
Implements flexible Safe Withdrawal Rate (SWR) support beyond the default 4% rule.

## Changes
- Add `SWRGuidance` interface and `SWR_GUIDANCE_TABLE` constant with rates for different retirement lengths
- Add `suggestWithdrawalRate()` to recommend SWR based on retirement duration
- Add `calculateRetirementTargetWithSWR()` for custom withdrawal rate calculations
- Create `withdrawalRateTools.ts` with SDK tool definitions
- Add 11 comprehensive tests for SWR calculations

## SWR Guidance Table
| Retirement Length | Standard SWR | Conservative SWR |
|-------------------|--------------|------------------|
| 20 years          | 5.0%         | 4.5%             |
| 25 years          | 4.5%         | 4.0%             |
| 30 years          | 4.0%         | 3.5%             |
| 35 years          | 3.5%         | 3.25%            |
| 40+ years         | 3.25%        | 3.0%             |

## New Tools
- `suggestWithdrawalRate` - Suggests appropriate SWR based on retirement length
- `calculateRetirementTargetWithSWR` - Calculates target savings with custom withdrawal rate

## Testing
All 72 tests pass.

Closes #9